### PR TITLE
Markdown docs

### DIFF
--- a/Apis/AccountManagementApi.md
+++ b/Apis/AccountManagementApi.md
@@ -1,0 +1,262 @@
+# AccountManagementApi
+
+All URIs are relative to *http://localhost*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**accountsIdPut**](AccountManagementApi.md#accountsIdPut) | **PUT** /accounts/{id} | 
+[**createAccount**](AccountManagementApi.md#createAccount) | **POST** /accounts | 
+[**createSubscription**](AccountManagementApi.md#createSubscription) | **POST** /subscriptions | 
+[**getAccountBalance**](AccountManagementApi.md#getAccountBalance) | **GET** /balances | 
+[**getAccountById**](AccountManagementApi.md#getAccountById) | **GET** /accounts/{id} | 
+[**getAccounts**](AccountManagementApi.md#getAccounts) | **GET** /accounts | 
+[**getPlans**](AccountManagementApi.md#getPlans) | **GET** /plans | 
+[**getSubscriptionById**](AccountManagementApi.md#getSubscriptionById) | **GET** /subscriptions/{id} | 
+[**getSubscriptionRecords**](AccountManagementApi.md#getSubscriptionRecords) | **GET** /subscriptions | 
+[**getTransactions**](AccountManagementApi.md#getTransactions) | **GET** /transactions | 
+
+
+<a name="accountsIdPut"></a>
+# **accountsIdPut**
+> inline_response_200_1 accountsIdPut(id, Account)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | **String**| ID of the account. | [default to null]
+ **Account** | [**Account**](../Models/Account.md)| Account to be created |
+
+### Return type
+
+[**inline_response_200_1**](../Models/inline_response_200_1.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+<a name="createAccount"></a>
+# **createAccount**
+> inline_response_200_1 createAccount(Account)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **Account** | [**Account**](../Models/Account.md)| Account to be created |
+
+### Return type
+
+[**inline_response_200_1**](../Models/inline_response_200_1.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+<a name="createSubscription"></a>
+# **createSubscription**
+> SubscriptionContainer createSubscription(Subscription)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **Subscription** | [**Subscription**](../Models/Subscription.md)| Subscription to be created |
+
+### Return type
+
+[**SubscriptionContainer**](../Models/SubscriptionContainer.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+<a name="getAccountBalance"></a>
+# **getAccountBalance**
+> inline_response_200_2 getAccountBalance(accountId)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **accountId** | **String**| The account whose current balance we want | [default to null]
+
+### Return type
+
+[**inline_response_200_2**](../Models/inline_response_200_2.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="getAccountById"></a>
+# **getAccountById**
+> inline_response_200_1 getAccountById(id)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | **String**| ID of the account. | [default to null]
+
+### Return type
+
+[**inline_response_200_1**](../Models/inline_response_200_1.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="getAccounts"></a>
+# **getAccounts**
+> inline_response_200 getAccounts()
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**inline_response_200**](../Models/inline_response_200.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="getPlans"></a>
+# **getPlans**
+> PlanArray getPlans()
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**PlanArray**](../Models/PlanArray.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="getSubscriptionById"></a>
+# **getSubscriptionById**
+> SubscriptionContainer getSubscriptionById(id)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | **String**| ID of the subscription. | [default to null]
+
+### Return type
+
+[**SubscriptionContainer**](../Models/SubscriptionContainer.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="getSubscriptionRecords"></a>
+# **getSubscriptionRecords**
+> List getSubscriptionRecords()
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**List**](../Models/Subscription.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="getTransactions"></a>
+# **getTransactions**
+> TransactionList getTransactions(accountId, fromTimestamp, toTimestamp)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **accountId** | **String**| The account whose transactions we want | [default to null]
+ **fromTimestamp** | **Date**| The timestamp from which to start searching | [optional] [default to null]
+ **toTimestamp** | **Date**| The timestamp from which to end searching | [optional] [default to null]
+
+### Return type
+
+[**TransactionList**](../Models/TransactionList.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+

--- a/Apis/AgentSessionsApi.md
+++ b/Apis/AgentSessionsApi.md
@@ -1,0 +1,61 @@
+# AgentSessionsApi
+
+All URIs are relative to *http://localhost*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**createAgentSession**](AgentSessionsApi.md#createAgentSession) | **POST** /session/{groupName} | 
+[**getAgentSessionState**](AgentSessionsApi.md#getAgentSessionState) | **GET** /session/{groupName} | 
+
+
+<a name="createAgentSession"></a>
+# **createAgentSession**
+> AgentSessionState createAgentSession(groupName, AgentSessionRequest)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **groupName** | **String**| Name for this group of agents. | [default to null]
+ **AgentSessionRequest** | [**AgentSessionRequest**](../Models/AgentSessionRequest.md)| Create a new agent and generate a new API key. |
+
+### Return type
+
+[**AgentSessionState**](../Models/AgentSessionState.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+<a name="getAgentSessionState"></a>
+# **getAgentSessionState**
+> AgentSessionState getAgentSessionState(groupName)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **groupName** | **String**| Name for this group of agents. | [default to null]
+
+### Return type
+
+[**AgentSessionState**](../Models/AgentSessionState.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+

--- a/Apis/AgentsApi.md
+++ b/Apis/AgentsApi.md
@@ -1,0 +1,136 @@
+# AgentsApi
+
+All URIs are relative to *http://localhost*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**agentsGet**](AgentsApi.md#agentsGet) | **GET** /agents | 
+[**agentsIdDelete**](AgentsApi.md#agentsIdDelete) | **DELETE** /agents/{id} | 
+[**agentsIdGet**](AgentsApi.md#agentsIdGet) | **GET** /agents/{id} | 
+[**agentsIdPut**](AgentsApi.md#agentsIdPut) | **PUT** /agents/{id} | 
+[**agentsPost**](AgentsApi.md#agentsPost) | **POST** /agents | 
+
+
+<a name="agentsGet"></a>
+# **agentsGet**
+> List agentsGet()
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**List**](../Models/Agent.md)
+
+### Authorization
+
+[BearerAuth](../README.md#BearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="agentsIdDelete"></a>
+# **agentsIdDelete**
+> Agent agentsIdDelete(id)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | **String**| ID of the alert. | [default to null]
+
+### Return type
+
+[**Agent**](../Models/Agent.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="agentsIdGet"></a>
+# **agentsIdGet**
+> Agent agentsIdGet(id)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | **String**| ID of the alert. | [default to null]
+
+### Return type
+
+[**Agent**](../Models/Agent.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="agentsIdPut"></a>
+# **agentsIdPut**
+> Agent agentsIdPut(id, Agent)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | **String**| ID of the alert. | [default to null]
+ **Agent** | [**Agent**](../Models/Agent.md)| Update an existing agent. |
+
+### Return type
+
+[**Agent**](../Models/Agent.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+<a name="agentsPost"></a>
+# **agentsPost**
+> Agent agentsPost(Agent)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **Agent** | [**Agent**](../Models/Agent.md)| Create a new agent and generate a new API key. |
+
+### Return type
+
+[**Agent**](../Models/Agent.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+

--- a/Apis/AlertsApi.md
+++ b/Apis/AlertsApi.md
@@ -1,0 +1,140 @@
+# AlertsApi
+
+All URIs are relative to *http://localhost*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**alertsGet**](AlertsApi.md#alertsGet) | **GET** /alerts | 
+[**alertsIdDelete**](AlertsApi.md#alertsIdDelete) | **DELETE** /alerts/{id} | 
+[**alertsIdGet**](AlertsApi.md#alertsIdGet) | **GET** /alerts/{id} | 
+[**alertsIdPut**](AlertsApi.md#alertsIdPut) | **PUT** /alerts/{id} | 
+[**alertsPost**](AlertsApi.md#alertsPost) | **POST** /alerts | 
+
+
+<a name="alertsGet"></a>
+# **alertsGet**
+> AlertArray alertsGet()
+
+
+
+    Retrieve all of the alerts you have created in your account.
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**AlertArray**](../Models/AlertArray.md)
+
+### Authorization
+
+[BearerAuth](../README.md#BearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="alertsIdDelete"></a>
+# **alertsIdDelete**
+> Alert alertsIdDelete(id)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | **String**| ID of the alert. | [default to null]
+
+### Return type
+
+[**Alert**](../Models/Alert.md)
+
+### Authorization
+
+[BearerAuth](../README.md#BearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="alertsIdGet"></a>
+# **alertsIdGet**
+> Alert alertsIdGet(id)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | **String**| ID of the alert. | [default to null]
+
+### Return type
+
+[**Alert**](../Models/Alert.md)
+
+### Authorization
+
+[BearerAuth](../README.md#BearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="alertsIdPut"></a>
+# **alertsIdPut**
+> Alert alertsIdPut(id, Alert)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | **String**| ID of the alert. | [default to null]
+ **Alert** | [**Alert**](../Models/Alert.md)| Update an existing alert. |
+
+### Return type
+
+[**Alert**](../Models/Alert.md)
+
+### Authorization
+
+[BearerAuth](../README.md#BearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+<a name="alertsPost"></a>
+# **alertsPost**
+> Alert alertsPost(Alert)
+
+
+
+    Create a new alert that can be activated when a monitor goes down. An alert can be a message (email, Microsoft teams), or it can call a web service (webhook). An alert is associated with zero or more of your monitors. If your alert has more than one monitor, the alert will be activated only when the number of monitors that goes down exceededs the &#x60;threshold&#x60;.
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **Alert** | [**Alert**](../Models/Alert.md)| Create a new alert. |
+
+### Return type
+
+[**Alert**](../Models/Alert.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+

--- a/Apis/AuthenticationApi.md
+++ b/Apis/AuthenticationApi.md
@@ -1,0 +1,31 @@
+# AuthenticationApi
+
+All URIs are relative to *http://localhost*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**authenticationJwtPost**](AuthenticationApi.md#authenticationJwtPost) | **POST** /authentication/jwt | Create an API token in the form of a JWT.
+
+
+<a name="authenticationJwtPost"></a>
+# **authenticationJwtPost**
+> JwtObject authenticationJwtPost()
+
+Create an API token in the form of a JWT.
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**JwtObject**](../Models/JwtObject.md)
+
+### Authorization
+
+[BasicAuth](../README.md#BasicAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+

--- a/Apis/ChallengeApi.md
+++ b/Apis/ChallengeApi.md
@@ -1,0 +1,57 @@
+# ChallengeApi
+
+All URIs are relative to *http://localhost*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**createChallenge**](ChallengeApi.md#createChallenge) | **POST** /challenge | Create a challenge to prove you are human
+[**updateChallenge**](ChallengeApi.md#updateChallenge) | **POST** /challenge/{id} | Solve a challenge and prove you are human.
+
+
+<a name="createChallenge"></a>
+# **createChallenge**
+> RegistrationChallenge createChallenge()
+
+Create a challenge to prove you are human
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**RegistrationChallenge**](../Models/RegistrationChallenge.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="updateChallenge"></a>
+# **updateChallenge**
+> RegistrationChallenge updateChallenge(id)
+
+Solve a challenge and prove you are human.
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | **String**| ID of registration to confirm. | [default to null]
+
+### Return type
+
+[**RegistrationChallenge**](../Models/RegistrationChallenge.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+

--- a/Apis/InfoApi.md
+++ b/Apis/InfoApi.md
@@ -1,0 +1,31 @@
+# InfoApi
+
+All URIs are relative to *http://localhost*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**getInfo**](InfoApi.md#getInfo) | **GET** /info | 
+
+
+<a name="getInfo"></a>
+# **getInfo**
+> ServerInfo getInfo()
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**ServerInfo**](../Models/ServerInfo.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+

--- a/Apis/MonitorsApi.md
+++ b/Apis/MonitorsApi.md
@@ -1,0 +1,140 @@
+# MonitorsApi
+
+All URIs are relative to *http://localhost*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**getMonitorById**](MonitorsApi.md#getMonitorById) | **GET** /monitors/{id} | Get a monitor by ID
+[**getMonitors**](MonitorsApi.md#getMonitors) | **GET** /monitors | Get a list of all monitors in your account.
+[**monitorsIdDelete**](MonitorsApi.md#monitorsIdDelete) | **DELETE** /monitors/{id} | 
+[**postMonitor**](MonitorsApi.md#postMonitor) | **POST** /monitors | Create a new monitor
+[**updateMonitor**](MonitorsApi.md#updateMonitor) | **PUT** /monitors/{id} | Update an existing monitor by ID
+
+
+<a name="getMonitorById"></a>
+# **getMonitorById**
+> Monitor getMonitorById(id)
+
+Get a monitor by ID
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | **String**| ID of monitor to retrieve. | [default to null]
+
+### Return type
+
+[**Monitor**](../Models/Monitor.md)
+
+### Authorization
+
+[BearerAuth](../README.md#BearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="getMonitors"></a>
+# **getMonitors**
+> MonitorArray getMonitors()
+
+Get a list of all monitors in your account.
+
+    Returns a collection of all monitors created.  
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**MonitorArray**](../Models/MonitorArray.md)
+
+### Authorization
+
+[BearerAuth](../README.md#BearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="monitorsIdDelete"></a>
+# **monitorsIdDelete**
+> Monitor monitorsIdDelete(id)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | **String**| ID of monitor to delete. | [default to null]
+
+### Return type
+
+[**Monitor**](../Models/Monitor.md)
+
+### Authorization
+
+[BearerAuth](../README.md#BearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="postMonitor"></a>
+# **postMonitor**
+> Monitor postMonitor(Monitor)
+
+Create a new monitor
+
+    Create a new monitor from the details in the request.
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **Monitor** | [**Monitor**](../Models/Monitor.md)| Specify what should be monitored and when. |
+
+### Return type
+
+[**Monitor**](../Models/Monitor.md)
+
+### Authorization
+
+[BearerAuth](../README.md#BearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+<a name="updateMonitor"></a>
+# **updateMonitor**
+> Monitor updateMonitor(id, Monitor)
+
+Update an existing monitor by ID
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | **String**| ID of monitor | [default to null]
+ **Monitor** | [**Monitor**](../Models/Monitor.md)| Specify what should be monitored and when. |
+
+### Return type
+
+[**Monitor**](../Models/Monitor.md)
+
+### Authorization
+
+[BearerAuth](../README.md#BearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+

--- a/Apis/RegistrationApi.md
+++ b/Apis/RegistrationApi.md
@@ -1,0 +1,63 @@
+# RegistrationApi
+
+All URIs are relative to *http://localhost*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**confirmRegistration**](RegistrationApi.md#confirmRegistration) | **POST** /registration/{id} | Confirm registration of Open Monitors account.
+[**createRegistration**](RegistrationApi.md#createRegistration) | **POST** /registration | Register your email address and password.
+
+
+<a name="confirmRegistration"></a>
+# **confirmRegistration**
+> confirmRegistration(id, RegistrationConfirmation)
+
+Confirm registration of Open Monitors account.
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | **String**| ID of registration to confirm. | [default to null]
+ **RegistrationConfirmation** | [**RegistrationConfirmation**](../Models/RegistrationConfirmation.md)| Details including confirmation code that prove the user&#39;s email address. |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+<a name="createRegistration"></a>
+# **createRegistration**
+> Registration createRegistration(Registration)
+
+Register your email address and password.
+
+    This is the endpoint you will use to create an account. This will enable you to use the API. By submitting your email address, password, and a name for your account, Open Monitors will email you a confirmation code. The confirmation code will be valid for 24 hours or less, and may only be used once. Note that this API will respond with a 200 response code even if your email address is in Open Monitor&#39;s system. This is for privacy reasons.
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **Registration** | [**Registration**](../Models/Registration.md)| Details for registering for an Open Monitors account. |
+
+### Return type
+
+[**Registration**](../Models/Registration.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+

--- a/Apis/RegistrationApi.md
+++ b/Apis/RegistrationApi.md
@@ -4,7 +4,7 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**confirmRegistration**](RegistrationApi.md#confirmRegistration) | **POST** /registration/{id} | Confirm registration of Open Monitors account.
+[**confirmRegistration**](RegistrationApi.md#confirmRegistration) | **POST** /registration/{id} | Confirm registration of account.
 [**createRegistration**](RegistrationApi.md#createRegistration) | **POST** /registration | Register your email address and password.
 
 
@@ -12,7 +12,7 @@ Method | HTTP request | Description
 # **confirmRegistration**
 > confirmRegistration(id, RegistrationConfirmation)
 
-Confirm registration of Open Monitors account.
+Confirm registration of account.
 
 ### Parameters
 
@@ -40,13 +40,13 @@ No authorization required
 
 Register your email address and password.
 
-    This is the endpoint you will use to create an account. This will enable you to use the API. By submitting your email address, password, and a name for your account, Open Monitors will email you a confirmation code. The confirmation code will be valid for 24 hours or less, and may only be used once. Note that this API will respond with a 200 response code even if your email address is in Open Monitor&#39;s system. This is for privacy reasons.
+    This is the endpoint you will use to create an account. This will enable you to use the API. By submitting your email address, password, and a name for your account, you will be emailed a confirmation code. The confirmation code will be valid for 24 hours or less, and may only be used once. Note that this API will respond with a 200 response code even if your email address is in Open Monitor&#39;s system. This is for privacy reasons.
 
 ### Parameters
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **Registration** | [**Registration**](../Models/Registration.md)| Details for registering for an Open Monitors account. |
+ **Registration** | [**Registration**](../Models/Registration.md)| Details for registering an account. |
 
 ### Return type
 

--- a/Apis/StatusesApi.md
+++ b/Apis/StatusesApi.md
@@ -1,0 +1,57 @@
+# StatusesApi
+
+All URIs are relative to *http://localhost*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**getMonitorStatuses**](StatusesApi.md#getMonitorStatuses) | **GET** /statuses | 
+[**updateMonitorStatuses**](StatusesApi.md#updateMonitorStatuses) | **POST** /statuses | 
+
+
+<a name="getMonitorStatuses"></a>
+# **getMonitorStatuses**
+> MonitorStatusArray getMonitorStatuses()
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**MonitorStatusArray**](../Models/MonitorStatusArray.md)
+
+### Authorization
+
+[BearerAuth](../README.md#BearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="updateMonitorStatuses"></a>
+# **updateMonitorStatuses**
+> updateMonitorStatuses(MonitorStatusArray)
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **MonitorStatusArray** | [**MonitorStatusArray**](../Models/MonitorStatusArray.md)| Specify what should be monitored and when. |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[BearerAuth](../README.md#BearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+

--- a/Models/Account.md
+++ b/Models/Account.md
@@ -1,0 +1,12 @@
+# Account
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | [**String**](string.md) |  | [default to null]
+**name** | [**String**](string.md) |  | [default to null]
+**type** | [**AccountType**](AccountType.md) |  | [default to null]
+**currencyCode** | [**CurrencyCode**](CurrencyCode.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/AccountType.md
+++ b/Models/AccountType.md
@@ -1,0 +1,8 @@
+# AccountType
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/Agent.md
+++ b/Models/Agent.md
@@ -1,0 +1,13 @@
+# Agent
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | [**String**](string.md) |  | [optional] [default to null]
+**name** | [**String**](string.md) |  | [default to null]
+**description** | [**String**](string.md) | Describes what this agent is or where it will run. | [optional] [default to null]
+**group** | [**String**](string.md) |  | [optional] [default to null]
+**apiKey** | [**String**](string.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/AgentSessionAssignment.md
+++ b/Models/AgentSessionAssignment.md
@@ -1,0 +1,12 @@
+# AgentSessionAssignment
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**sessionId** | [**String**](string.md) |  | [default to null]
+**agentId** | [**String**](string.md) |  | [default to null]
+**monitorIds** | [**List**](string.md) |  | [default to null]
+**lastHeartbeatTimestamp** | [**Integer**](integer.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/AgentSessionRequest.md
+++ b/Models/AgentSessionRequest.md
@@ -1,0 +1,10 @@
+# AgentSessionRequest
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**sessionId** | [**String**](string.md) |  | [default to null]
+**isNew** | [**Boolean**](boolean.md) | Optional indicator that tells the server that this is a new session. | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/AgentSessionState.md
+++ b/Models/AgentSessionState.md
@@ -1,0 +1,10 @@
+# AgentSessionState
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**group** | [**String**](string.md) |  | [default to null]
+**agents** | [**List**](AgentSessionAssignment.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/Alert.md
+++ b/Models/Alert.md
@@ -1,0 +1,15 @@
+# Alert
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**type** | [**String**](string.md) |  | [default to null]
+**id** | [**String**](string.md) |  | [optional] [default to null]
+**description** | [**String**](string.md) | Describes what your alert will do. | [optional] [default to null]
+**monitors** | [**List**](string.md) |  | [default to null]
+**threshold** | [**Integer**](integer.md) |  | [default to null]
+**enabled** | [**Boolean**](boolean.md) |  | [default to null]
+**body** | [**AlertBody**](AlertBody.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/AlertArray.md
+++ b/Models/AlertArray.md
@@ -1,0 +1,9 @@
+# AlertArray
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**alerts** | [**List**](Alert.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/AlertBody.md
+++ b/Models/AlertBody.md
@@ -1,0 +1,17 @@
+# AlertBody
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**url** | [**String**](string.md) |  | [optional] [default to null]
+**headers** | [**List**](HttpHeader.md) |  | [optional] [default to null]
+**from** | [**String**](string.md) |  | [optional] [default to null]
+**recipients** | [**List**](string.md) | The addresses to which the alert email will be sent. | [optional] [default to null]
+**host** | [**String**](string.md) | Your SMTP server&#39;s hostname | [optional] [default to null]
+**port** | [**BigDecimal**](number.md) | The port number for your SMTP server | [optional] [default to null]
+**tlsMode** | [**TlsMode**](TlsMode.md) |  | [optional] [default to null]
+**username** | [**String**](string.md) |  | [optional] [default to null]
+**password** | [**String**](string.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/Balance.md
+++ b/Models/Balance.md
@@ -1,0 +1,12 @@
+# Balance
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**accountId** | [**String**](string.md) |  | [default to null]
+**timestamp** | [**Date**](DateTime.md) |  | [default to null]
+**balance** | [**Money**](Money.md) |  | [default to null]
+**availableBalance** | [**Money**](Money.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/Balances.md
+++ b/Models/Balances.md
@@ -1,0 +1,9 @@
+# Balances
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**balances** | [**List**](Balance.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/ChargeType.md
+++ b/Models/ChargeType.md
@@ -1,0 +1,8 @@
+# ChargeType
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/CurrencyCode.md
+++ b/Models/CurrencyCode.md
@@ -1,0 +1,8 @@
+# CurrencyCode
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/EmailAlertBody.md
+++ b/Models/EmailAlertBody.md
@@ -1,0 +1,15 @@
+# EmailAlertBody
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**from** | [**String**](string.md) |  | [optional] [default to null]
+**recipients** | [**List**](string.md) | The addresses to which the alert email will be sent. | [optional] [default to null]
+**host** | [**String**](string.md) | Your SMTP server&#39;s hostname | [optional] [default to null]
+**port** | [**BigDecimal**](number.md) | The port number for your SMTP server | [optional] [default to null]
+**tlsMode** | [**TlsMode**](TlsMode.md) |  | [optional] [default to null]
+**username** | [**String**](string.md) |  | [optional] [default to null]
+**password** | [**String**](string.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/ErrorCode.md
+++ b/Models/ErrorCode.md
@@ -1,0 +1,8 @@
+# ErrorCode
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/ErrorList.md
+++ b/Models/ErrorList.md
@@ -1,0 +1,9 @@
+# ErrorList
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**errors** | [**List**](ResponseError.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/HttpHeader.md
+++ b/Models/HttpHeader.md
@@ -1,0 +1,10 @@
+# HttpHeader
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**name** | [**String**](string.md) |  | [default to null]
+**value** | [**String**](string.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/HttpMonitorBody.md
+++ b/Models/HttpMonitorBody.md
@@ -1,0 +1,12 @@
+# HttpMonitorBody
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**url** | [**String**](string.md) |  | [optional] [default to null]
+**method** | [**String**](string.md) |  | [optional] [default to null]
+**headers** | [**List**](HttpHeader.md) |  | [optional] [default to null]
+**body** | [**String**](string.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/InlineResponse200.md
+++ b/Models/InlineResponse200.md
@@ -1,0 +1,9 @@
+# InlineResponse200
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**accounts** | [**List**](Account.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/InlineResponse2001.md
+++ b/Models/InlineResponse2001.md
@@ -1,0 +1,9 @@
+# InlineResponse2001
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**account** | [**Account**](Account.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/InlineResponse2002.md
+++ b/Models/InlineResponse2002.md
@@ -1,0 +1,9 @@
+# InlineResponse2002
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**balance** | [**Balance**](Balance.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/JwtObject.md
+++ b/Models/JwtObject.md
@@ -1,0 +1,13 @@
+# JwtObject
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**jwt** | [**String**](string.md) | The JSON Web Token that can be used to access the API. | [default to null]
+**jwtExpiry** | [**BigDecimal**](number.md) | Time at which the JWT expires in seconds since Unix Epoc | [default to null]
+**jwtScopes** | [**List**](string.md) |  | [default to null]
+**refreshToken** | [**String**](string.md) | A Bearer token that can used to get a new JWT. | [default to null]
+**refreshTokenExpiry** | [**BigDecimal**](number.md) | Time at which the refresh token expires in seconds since Unix Epoc | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/Money.md
+++ b/Models/Money.md
@@ -1,0 +1,11 @@
+# Money
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**value** | [**Integer**](integer.md) |  | [default to null]
+**decimalPlaces** | [**Integer**](integer.md) |  | [default to null]
+**currencyCode** | [**CurrencyCode**](CurrencyCode.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/Monitor.md
+++ b/Models/Monitor.md
@@ -1,0 +1,16 @@
+# Monitor
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | [**String**](string.md) |  | [optional] [default to null]
+**type** | [**MonitorType**](MonitorType.md) |  | [default to null]
+**enabled** | [**Boolean**](boolean.md) |  | [default to true]
+**name** | [**String**](string.md) |  | [default to null]
+**description** | [**String**](string.md) | Describes what this monitor checks. | [optional] [default to null]
+**period** | [**String**](string.md) |  | [default to null]
+**timeout** | [**String**](string.md) |  | [default to null]
+**body** | [**MonitorBody**](MonitorBody.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/MonitorArray.md
+++ b/Models/MonitorArray.md
@@ -1,0 +1,9 @@
+# MonitorArray
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**monitors** | [**List**](Monitor.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/MonitorBody.md
+++ b/Models/MonitorBody.md
@@ -1,0 +1,20 @@
+# MonitorBody
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**url** | [**String**](string.md) |  | [optional] [default to null]
+**method** | [**String**](string.md) |  | [optional] [default to null]
+**headers** | [**List**](HttpHeader.md) |  | [optional] [default to null]
+**body** | [**String**](string.md) |  | [optional] [default to null]
+**executable** | [**String**](string.md) | The name of the executable process to be monitored. | [optional] [default to null]
+**isPathAbsolute** | [**Boolean**](boolean.md) | If true, the process(s) will be located by the full path of the executable e.g. /usr/bin/node | [optional] [default to false]
+**minimumCount** | [**Integer**](integer.md) | The minimum number of processes that match the executable. | [optional] [default to null]
+**maximumCount** | [**Integer**](integer.md) | The maximum number of processes that match the executable.  | [optional] [default to null]
+**maximumRamIndividual** | [**String**](string.md) |  | [optional] [default to null]
+**maximumRamTotal** | [**String**](string.md) |  | [optional] [default to null]
+**hostname** | [**String**](string.md) |  | [optional] [default to null]
+**port** | [**Integer**](integer.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/MonitorStatus.md
+++ b/Models/MonitorStatus.md
@@ -1,0 +1,14 @@
+# MonitorStatus
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**monitorId** | [**String**](string.md) |  | [default to null]
+**status** | [**MonitorStatusIndicator**](MonitorStatusIndicator.md) |  | [default to null]
+**timestamp** | [**Date**](DateTime.md) |  | [default to null]
+**lastResult** | [**MonitorStatusResult**](MonitorStatusResult.md) |  | [default to null]
+**description** | [**String**](string.md) |  | [default to null]
+**log** | [**List**](MonitorStatusLogEntry.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/MonitorStatusArray.md
+++ b/Models/MonitorStatusArray.md
@@ -1,0 +1,9 @@
+# MonitorStatusArray
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**statuses** | [**List**](MonitorStatus.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/MonitorStatusIndicator.md
+++ b/Models/MonitorStatusIndicator.md
@@ -1,0 +1,8 @@
+# MonitorStatusIndicator
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/MonitorStatusLogEntry.md
+++ b/Models/MonitorStatusLogEntry.md
@@ -1,0 +1,10 @@
+# MonitorStatusLogEntry
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**timestamp** | [**Date**](DateTime.md) |  | [default to null]
+**value** | [**String**](string.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/MonitorStatusResult.md
+++ b/Models/MonitorStatusResult.md
@@ -1,0 +1,10 @@
+# MonitorStatusResult
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**expected** | [**String**](string.md) |  | [default to null]
+**actual** | [**String**](string.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/MonitorType.md
+++ b/Models/MonitorType.md
@@ -1,0 +1,8 @@
+# MonitorType
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/MsTeamsAlertBody.md
+++ b/Models/MsTeamsAlertBody.md
@@ -1,0 +1,9 @@
+# MsTeamsAlertBody
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**url** | [**String**](string.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/NewAgent.md
+++ b/Models/NewAgent.md
@@ -1,0 +1,13 @@
+# NewAgent
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**apiKey** | [**String**](string.md) |  | [default to null]
+**id** | [**String**](string.md) |  | [optional] [default to null]
+**name** | [**String**](string.md) |  | [default to null]
+**description** | [**String**](string.md) | Describes what this agent is or where it will run. | [optional] [default to null]
+**group** | [**String**](string.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/Plan.md
+++ b/Models/Plan.md
@@ -1,0 +1,13 @@
+# Plan
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | [**String**](string.md) |  | [default to null]
+**name** | [**String**](string.md) | Description of what this plan is for, and what it offers. | [default to null]
+**description** | [**String**](string.md) | Description of what this plan is for, and what it offers. | [default to null]
+**products** | [**List**](Product.md) |  | [default to null]
+**maximumPrice** | [**Money**](Money.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/PlanArray.md
+++ b/Models/PlanArray.md
@@ -1,0 +1,9 @@
+# PlanArray
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**plans** | [**List**](Plan.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/ProcessMonitorBody.md
+++ b/Models/ProcessMonitorBody.md
@@ -1,0 +1,14 @@
+# ProcessMonitorBody
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**executable** | [**String**](string.md) | The name of the executable process to be monitored. | [optional] [default to null]
+**isPathAbsolute** | [**Boolean**](boolean.md) | If true, the process(s) will be located by the full path of the executable e.g. /usr/bin/node | [optional] [default to false]
+**minimumCount** | [**Integer**](integer.md) | The minimum number of processes that match the executable. | [optional] [default to null]
+**maximumCount** | [**Integer**](integer.md) | The maximum number of processes that match the executable.  | [optional] [default to null]
+**maximumRamIndividual** | [**String**](string.md) |  | [optional] [default to null]
+**maximumRamTotal** | [**String**](string.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/Product.md
+++ b/Models/Product.md
@@ -1,0 +1,12 @@
+# Product
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**entity** | [**ProductEntity**](ProductEntity.md) |  | [default to null]
+**price** | [**Money**](Money.md) |  | [default to null]
+**count** | [**Integer**](integer.md) |  | [default to null]
+**description** | [**String**](string.md) | 15 monitors for free. | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/ProductEntity.md
+++ b/Models/ProductEntity.md
@@ -1,0 +1,8 @@
+# ProductEntity
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/Registration.md
+++ b/Models/Registration.md
@@ -1,0 +1,14 @@
+# Registration
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | [**String**](string.md) |  | [optional] [default to null]
+**accountName** | [**String**](string.md) |  | [default to null]
+**challengeId** | [**String**](string.md) |  | [default to null]
+**challengeSolution** | [**String**](string.md) |  | [default to null]
+**emailAddress** | [**String**](string.md) |  | [default to null]
+**password** | [**String**](string.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/RegistrationChallenge.md
+++ b/Models/RegistrationChallenge.md
@@ -1,0 +1,16 @@
+# RegistrationChallenge
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | [**String**](string.md) |  | [optional] [default to null]
+**status** | [**String**](string.md) |  | [optional] [default to null]
+**solution** | [**String**](string.md) | The solution that will activate the challenge. This can be used to prove you are human. | [optional] [default to null]
+**type** | [**String**](string.md) | What the user has to do to pass the challenge. For now this is just &#x60;image&#x60;. | [default to null]
+**encoding** | [**String**](string.md) | Since this is a JSON api, the image data has to be encoded in some way. For now image data is encoded in base 64. | [default to null]
+**mimeType** | [**String**](string.md) | Describes how to interpret the &#x60;data&#x60; field. | [default to null]
+**url** | [**String**](string.md) | The URL for the image, if there is one. | [optional] [default to null]
+**data** | [**String**](string.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/RegistrationConfirmation.md
+++ b/Models/RegistrationConfirmation.md
@@ -1,0 +1,11 @@
+# RegistrationConfirmation
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | [**String**](string.md) |  | [default to null]
+**confirmationCode** | [**String**](string.md) | A secret string between the client and the API. A valid confirmation code is proof the user owns the email address | [default to null]
+**emailAddress** | [**String**](string.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/ResponseError.md
+++ b/Models/ResponseError.md
@@ -1,0 +1,11 @@
+# ResponseError
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**errorCode** | [**ErrorCode**](ErrorCode.md) |  | [default to null]
+**errorMessage** | [**String**](string.md) |  | [default to null]
+**userErrorMessage** | [**String**](string.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/ServerInfo.md
+++ b/Models/ServerInfo.md
@@ -1,0 +1,11 @@
+# ServerInfo
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**vcsRef** | [**String**](string.md) |  | [optional] [default to null]
+**processMemoryBytes** | [**BigDecimal**](number.md) |  | [default to null]
+**openInwardConnections** | [**BigDecimal**](number.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/Subscription.md
+++ b/Models/Subscription.md
@@ -1,0 +1,14 @@
+# Subscription
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | [**String**](string.md) |  | [optional] [default to null]
+**organisationId** | [**String**](string.md) |  | [optional] [default to null]
+**startedAt** | [**Date**](DateTime.md) |  | [optional] [default to null]
+**stoppedAt** | [**Date**](DateTime.md) |  | [optional] [default to null]
+**planId** | [**String**](string.md) |  | [default to null]
+**chargeType** | [**ChargeType**](ChargeType.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/SubscriptionContainer.md
+++ b/Models/SubscriptionContainer.md
@@ -1,0 +1,9 @@
+# SubscriptionContainer
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**subscription** | [**Subscription**](Subscription.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/SubscriptionStatus.md
+++ b/Models/SubscriptionStatus.md
@@ -1,0 +1,8 @@
+# SubscriptionStatus
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/TcpMonitorBody.md
+++ b/Models/TcpMonitorBody.md
@@ -1,0 +1,10 @@
+# TcpMonitorBody
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**hostname** | [**String**](string.md) |  | [optional] [default to null]
+**port** | [**Integer**](integer.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/TlsMode.md
+++ b/Models/TlsMode.md
@@ -1,0 +1,8 @@
+# TlsMode
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/Transaction.md
+++ b/Models/Transaction.md
@@ -1,0 +1,13 @@
+# Transaction
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | [**String**](string.md) |  | [default to null]
+**timestamp** | [**Date**](DateTime.md) |  | [default to null]
+**amount** | [**Money**](Money.md) |  | [default to null]
+**description** | [**String**](string.md) |  | [default to null]
+**code** | [**TransactionCode**](TransactionCode.md) |  | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/TransactionCode.md
+++ b/Models/TransactionCode.md
@@ -1,0 +1,8 @@
+# TransactionCode
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/TransactionList.md
+++ b/Models/TransactionList.md
@@ -1,0 +1,11 @@
+# TransactionList
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**transactions** | [**List**](Transaction.md) |  | [optional] [default to null]
+**openingBalance** | [**Balance**](Balance.md) |  | [optional] [default to null]
+**closingBalance** | [**Balance**](Balance.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/Models/WebhookAlertBody.md
+++ b/Models/WebhookAlertBody.md
@@ -1,0 +1,10 @@
+# WebhookAlertBody
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**url** | [**String**](string.md) |  | [optional] [default to null]
+**headers** | [**List**](HttpHeader.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Documentation for Open Monitors
+# Documentation for Schnooty API
 
 <a name="documentation-for-api-endpoints"></a>
 ## Documentation for API Endpoints
@@ -38,7 +38,7 @@ Class | Method | HTTP request | Description
 *MonitorsApi* | [**monitorsIdDelete**](Apis/MonitorsApi.md#monitorsiddelete) | **DELETE** /monitors/{id} | 
 *MonitorsApi* | [**postMonitor**](Apis/MonitorsApi.md#postmonitor) | **POST** /monitors | Create a new monitor
 *MonitorsApi* | [**updateMonitor**](Apis/MonitorsApi.md#updatemonitor) | **PUT** /monitors/{id} | Update an existing monitor by ID
-*RegistrationApi* | [**confirmRegistration**](Apis/RegistrationApi.md#confirmregistration) | **POST** /registration/{id} | Confirm registration of Open Monitors account.
+*RegistrationApi* | [**confirmRegistration**](Apis/RegistrationApi.md#confirmregistration) | **POST** /registration/{id} | Confirm registration of account.
 *RegistrationApi* | [**createRegistration**](Apis/RegistrationApi.md#createregistration) | **POST** /registration | Register your email address and password.
 *StatusesApi* | [**getMonitorStatuses**](Apis/StatusesApi.md#getmonitorstatuses) | **GET** /statuses | 
 *StatusesApi* | [**updateMonitorStatuses**](Apis/StatusesApi.md#updatemonitorstatuses) | **POST** /statuses | 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,117 @@
-TBC
+# Documentation for Open Monitors
+
+<a name="documentation-for-api-endpoints"></a>
+## Documentation for API Endpoints
+
+All URIs are relative to *http://localhost*
+
+Class | Method | HTTP request | Description
+------------ | ------------- | ------------- | -------------
+*AccountManagementApi* | [**accountsIdPut**](Apis/AccountManagementApi.md#accountsidput) | **PUT** /accounts/{id} | 
+*AccountManagementApi* | [**createAccount**](Apis/AccountManagementApi.md#createaccount) | **POST** /accounts | 
+*AccountManagementApi* | [**createSubscription**](Apis/AccountManagementApi.md#createsubscription) | **POST** /subscriptions | 
+*AccountManagementApi* | [**getAccountBalance**](Apis/AccountManagementApi.md#getaccountbalance) | **GET** /balances | 
+*AccountManagementApi* | [**getAccountById**](Apis/AccountManagementApi.md#getaccountbyid) | **GET** /accounts/{id} | 
+*AccountManagementApi* | [**getAccounts**](Apis/AccountManagementApi.md#getaccounts) | **GET** /accounts | 
+*AccountManagementApi* | [**getPlans**](Apis/AccountManagementApi.md#getplans) | **GET** /plans | 
+*AccountManagementApi* | [**getSubscriptionById**](Apis/AccountManagementApi.md#getsubscriptionbyid) | **GET** /subscriptions/{id} | 
+*AccountManagementApi* | [**getSubscriptionRecords**](Apis/AccountManagementApi.md#getsubscriptionrecords) | **GET** /subscriptions | 
+*AccountManagementApi* | [**getTransactions**](Apis/AccountManagementApi.md#gettransactions) | **GET** /transactions | 
+*AgentSessionsApi* | [**createAgentSession**](Apis/AgentSessionsApi.md#createagentsession) | **POST** /session/{groupName} | 
+*AgentSessionsApi* | [**getAgentSessionState**](Apis/AgentSessionsApi.md#getagentsessionstate) | **GET** /session/{groupName} | 
+*AgentsApi* | [**agentsGet**](Apis/AgentsApi.md#agentsget) | **GET** /agents | 
+*AgentsApi* | [**agentsIdDelete**](Apis/AgentsApi.md#agentsiddelete) | **DELETE** /agents/{id} | 
+*AgentsApi* | [**agentsIdGet**](Apis/AgentsApi.md#agentsidget) | **GET** /agents/{id} | 
+*AgentsApi* | [**agentsIdPut**](Apis/AgentsApi.md#agentsidput) | **PUT** /agents/{id} | 
+*AgentsApi* | [**agentsPost**](Apis/AgentsApi.md#agentspost) | **POST** /agents | 
+*AlertsApi* | [**alertsGet**](Apis/AlertsApi.md#alertsget) | **GET** /alerts | Retrieve all of the alerts you have created in your account.
+*AlertsApi* | [**alertsIdDelete**](Apis/AlertsApi.md#alertsiddelete) | **DELETE** /alerts/{id} | 
+*AlertsApi* | [**alertsIdGet**](Apis/AlertsApi.md#alertsidget) | **GET** /alerts/{id} | 
+*AlertsApi* | [**alertsIdPut**](Apis/AlertsApi.md#alertsidput) | **PUT** /alerts/{id} | 
+*AlertsApi* | [**alertsPost**](Apis/AlertsApi.md#alertspost) | **POST** /alerts | Create a new alert that can be activated when a monitor goes down. An alert can be a message (email, Microsoft teams), or it can call a web service (webhook). An alert is associated with zero or more of your monitors. If your alert has more than one monitor, the alert will be activated only when the number of monitors that goes down exceededs the `threshold`.
+*AuthenticationApi* | [**authenticationJwtPost**](Apis/AuthenticationApi.md#authenticationjwtpost) | **POST** /authentication/jwt | Create an API token in the form of a JWT.
+*ChallengeApi* | [**createChallenge**](Apis/ChallengeApi.md#createchallenge) | **POST** /challenge | Create a challenge to prove you are human
+*ChallengeApi* | [**updateChallenge**](Apis/ChallengeApi.md#updatechallenge) | **POST** /challenge/{id} | Solve a challenge and prove you are human.
+*InfoApi* | [**getInfo**](Apis/InfoApi.md#getinfo) | **GET** /info | 
+*MonitorsApi* | [**getMonitorById**](Apis/MonitorsApi.md#getmonitorbyid) | **GET** /monitors/{id} | Get a monitor by ID
+*MonitorsApi* | [**getMonitors**](Apis/MonitorsApi.md#getmonitors) | **GET** /monitors | Get a list of all monitors in your account.
+*MonitorsApi* | [**monitorsIdDelete**](Apis/MonitorsApi.md#monitorsiddelete) | **DELETE** /monitors/{id} | 
+*MonitorsApi* | [**postMonitor**](Apis/MonitorsApi.md#postmonitor) | **POST** /monitors | Create a new monitor
+*MonitorsApi* | [**updateMonitor**](Apis/MonitorsApi.md#updatemonitor) | **PUT** /monitors/{id} | Update an existing monitor by ID
+*RegistrationApi* | [**confirmRegistration**](Apis/RegistrationApi.md#confirmregistration) | **POST** /registration/{id} | Confirm registration of Open Monitors account.
+*RegistrationApi* | [**createRegistration**](Apis/RegistrationApi.md#createregistration) | **POST** /registration | Register your email address and password.
+*StatusesApi* | [**getMonitorStatuses**](Apis/StatusesApi.md#getmonitorstatuses) | **GET** /statuses | 
+*StatusesApi* | [**updateMonitorStatuses**](Apis/StatusesApi.md#updatemonitorstatuses) | **POST** /statuses | 
+
+
+<a name="documentation-for-models"></a>
+## Documentation for Models
+
+ - [Account](./Models/Account.md)
+ - [AccountType](./Models/AccountType.md)
+ - [Agent](./Models/Agent.md)
+ - [AgentSessionAssignment](./Models/AgentSessionAssignment.md)
+ - [AgentSessionRequest](./Models/AgentSessionRequest.md)
+ - [AgentSessionState](./Models/AgentSessionState.md)
+ - [Alert](./Models/Alert.md)
+ - [AlertArray](./Models/AlertArray.md)
+ - [AlertBody](./Models/AlertBody.md)
+ - [Balance](./Models/Balance.md)
+ - [Balances](./Models/Balances.md)
+ - [ChargeType](./Models/ChargeType.md)
+ - [CurrencyCode](./Models/CurrencyCode.md)
+ - [EmailAlertBody](./Models/EmailAlertBody.md)
+ - [ErrorCode](./Models/ErrorCode.md)
+ - [ErrorList](./Models/ErrorList.md)
+ - [HttpHeader](./Models/HttpHeader.md)
+ - [HttpMonitorBody](./Models/HttpMonitorBody.md)
+ - [InlineResponse200](./Models/InlineResponse200.md)
+ - [InlineResponse2001](./Models/InlineResponse2001.md)
+ - [InlineResponse2002](./Models/InlineResponse2002.md)
+ - [JwtObject](./Models/JwtObject.md)
+ - [Money](./Models/Money.md)
+ - [Monitor](./Models/Monitor.md)
+ - [MonitorArray](./Models/MonitorArray.md)
+ - [MonitorBody](./Models/MonitorBody.md)
+ - [MonitorStatus](./Models/MonitorStatus.md)
+ - [MonitorStatusArray](./Models/MonitorStatusArray.md)
+ - [MonitorStatusIndicator](./Models/MonitorStatusIndicator.md)
+ - [MonitorStatusLogEntry](./Models/MonitorStatusLogEntry.md)
+ - [MonitorStatusResult](./Models/MonitorStatusResult.md)
+ - [MonitorType](./Models/MonitorType.md)
+ - [MsTeamsAlertBody](./Models/MsTeamsAlertBody.md)
+ - [NewAgent](./Models/NewAgent.md)
+ - [Plan](./Models/Plan.md)
+ - [PlanArray](./Models/PlanArray.md)
+ - [ProcessMonitorBody](./Models/ProcessMonitorBody.md)
+ - [Product](./Models/Product.md)
+ - [ProductEntity](./Models/ProductEntity.md)
+ - [Registration](./Models/Registration.md)
+ - [RegistrationChallenge](./Models/RegistrationChallenge.md)
+ - [RegistrationConfirmation](./Models/RegistrationConfirmation.md)
+ - [ResponseError](./Models/ResponseError.md)
+ - [ServerInfo](./Models/ServerInfo.md)
+ - [Subscription](./Models/Subscription.md)
+ - [SubscriptionContainer](./Models/SubscriptionContainer.md)
+ - [SubscriptionStatus](./Models/SubscriptionStatus.md)
+ - [TcpMonitorBody](./Models/TcpMonitorBody.md)
+ - [TlsMode](./Models/TlsMode.md)
+ - [Transaction](./Models/Transaction.md)
+ - [TransactionCode](./Models/TransactionCode.md)
+ - [TransactionList](./Models/TransactionList.md)
+ - [WebhookAlertBody](./Models/WebhookAlertBody.md)
+
+
+<a name="documentation-for-authorization"></a>
+## Documentation for Authorization
+
+<a name="BasicAuth"></a>
+### BasicAuth
+
+- **Type**: HTTP basic authentication
+
+<a name="BearerAuth"></a>
+### BearerAuth
+
+- **Type**: HTTP basic authentication
+

--- a/api.yaml
+++ b/api.yaml
@@ -1,11 +1,10 @@
 openapi: "3.0.0"
 info:
-  description: "This is the Open Monitors API. All operations that a user or an agent would want to complete, including signing up, are listed here."
+  description: "This is the Schnooty API. It is used by both our agent and web application to manage your monitors, agents, alerts, account settings and everything else"
   version: "1.0.0"
-  title: "Open Monitors"
-  termsOfService: "http://www.openmonitors.com/terms/"
+  title: "Schnooty API"
   contact:
-    email: "support@openmonitors.com"
+    email: "support@schnooty.com"
   license:
     name: "Apache 2.0"
     url: "http://www.apache.org/licenses/LICENSE-2.0.html"
@@ -70,10 +69,10 @@ paths:
       tags: 
         - "Registration"
       summary: "Register your email address and password."
-      description: "This is the endpoint you will use to create an account. This will enable you to use the API. By submitting your email address, password, and a name for your account, Open Monitors will email you a confirmation code. The confirmation code will be valid for 24 hours or less, and may only be used once. Note that this API will respond with a 200 response code even if your email address is in Open Monitor's system. This is for privacy reasons."
+      description: "This is the endpoint you will use to create an account. This will enable you to use the API. By submitting your email address, password, and a name for your account, you will be emailed a confirmation code. The confirmation code will be valid for 24 hours or less, and may only be used once. Note that this API will respond with a 200 response code even if your email address is in Open Monitor's system. This is for privacy reasons."
       operationId: "create_registration"
       requestBody:
-        description: "Details for registering for an Open Monitors account."
+        description: "Details for registering an account."
         required: true
         content:
           application/json:
@@ -91,7 +90,7 @@ paths:
     post:
       tags: 
         - "Registration"
-      summary: "Confirm registration of Open Monitors account."
+      summary: "Confirm registration of account."
       parameters: 
         - name: id
           in: path

--- a/generate.sh
+++ b/generate.sh
@@ -1,4 +1,5 @@
 alias openapi-generator=/usr/sbin/run-in-docker.sh
 
-openapi-generator generate -i api.yaml -g rust-server -o rust
-openapi-generator generate -i api.yaml -g typescript-fetch -o javascript
+#openapi-generator generate -i api.yaml -g rust-server -o rust
+#openapi-generator generate -i api.yaml -g typescript-fetch -o javascript
+openapi-generator generate -i api.yaml -g markdown


### PR DESCRIPTION
This adds the documentation as generated by OpenAPI generator. 

Some entities in api.yaml are missing descriptions and other useful information. Adding these in the future will improve the documentation.